### PR TITLE
Null checks on fields

### DIFF
--- a/src/main/java/me/shivzee/JMailTM.java
+++ b/src/main/java/me/shivzee/JMailTM.java
@@ -93,7 +93,7 @@ public class JMailTM {
         Boolean isDeleted = safeEval(() -> (Boolean) json.get("isDeleted"));
         String createdAt = safeEval(() -> json.get("createdAt").toString());
         String updatedAt = safeEval(() -> json.get("updatedAt").toString());
-        return new Account(id,email,quota,used, Boolean.TRUE.equals(isDisabled), Boolean.TRUE.equals(isDeleted),createdAt,updatedAt);
+        return new Account(id,email,quota,used, isDisabled, isDeleted,createdAt,updatedAt);
     }
 
     private Message messageUtility(JSONObject json) throws ParseException, DateTimeParserException {
@@ -139,7 +139,7 @@ public class JMailTM {
                     aSize = Long.parseLong(strSize);
                 }
                 String aDownloadUrl = safeEval(() -> object.get("downloadUrl").toString());
-                attachments.add(new Attachment(aId, aFilename, aContentType, aDisposition, aTransferEncoding, Boolean.TRUE.equals(aRelated), aSize, aDownloadUrl, bearerToken));
+                attachments.add(new Attachment(aId, aFilename, aContentType, aDisposition, aTransferEncoding, aRelated, aSize, aDownloadUrl, bearerToken));
             }
         }
 

--- a/src/main/java/me/shivzee/JMailTM.java
+++ b/src/main/java/me/shivzee/JMailTM.java
@@ -119,20 +119,22 @@ public class JMailTM {
         boolean hasAttachments = (boolean) json.get("hasAttachments");
 
         List<Attachment> attachments = new ArrayList<>();
-        JSONArray attachmentArray = (JSONArray) parser.parse(json.get("attachments").toString());
-        Object [] aArray = attachmentArray.toArray();
+        if(hasAttachments) {
+            JSONArray attachmentArray = (JSONArray) parser.parse(json.get("attachments").toString());
+            Object[] aArray = attachmentArray.toArray();
 
-        for(Object attachmentObject : aArray){
-            JSONObject object = (JSONObject) attachmentObject;
-            String aId = object.get("id").toString();
-            String aFilename = object.get("filename").toString();
-            String aContentType = object.get("contentType").toString();
-            String aDisposition = object.get("disposition").toString();
-            String aTransferEncoding = object.get("transferEncoding").toString();
-            boolean aRelated = (boolean) object.get("related");
-            long aSize = Long.parseLong(object.get("size").toString());
-            String aDownloadUrl = object.get("downloadUrl").toString();
-            attachments.add(new Attachment(aId , aFilename , aContentType , aDisposition, aTransferEncoding ,aRelated ,aSize , aDownloadUrl ,bearerToken));
+            for (Object attachmentObject : aArray) {
+                JSONObject object = (JSONObject) attachmentObject;
+                String aId = object.get("id").toString();
+                String aFilename = object.get("filename").toString();
+                String aContentType = object.get("contentType").toString();
+                String aDisposition = object.get("disposition").toString();
+                String aTransferEncoding = object.get("transferEncoding").toString();
+                boolean aRelated = (boolean) object.get("related");
+                long aSize = Long.parseLong(object.get("size").toString());
+                String aDownloadUrl = object.get("downloadUrl").toString();
+                attachments.add(new Attachment(aId, aFilename, aContentType, aDisposition, aTransferEncoding, aRelated, aSize, aDownloadUrl, bearerToken));
+            }
         }
 
         long size = Long.parseLong(json.get("size").toString());

--- a/src/main/java/me/shivzee/util/Account.java
+++ b/src/main/java/me/shivzee/util/Account.java
@@ -8,8 +8,8 @@ public class Account {
     private String email;
     private String quota;
     private String used;
-    private boolean isDisabled;
-    private boolean isDeleted;
+    private Boolean isDisabled;
+    private Boolean isDeleted;
     private String createdAt;
     private String updatedAt;
 
@@ -23,7 +23,7 @@ public class Account {
         this.createdAt = "";
         this.updatedAt = "";
     }
-    public Account(String id, String email, String quota, String used, boolean isDisabled, boolean isDeleted, String createdAt, String updatedAt) {
+    public Account(String id, String email, String quota, String used, Boolean isDisabled, Boolean isDeleted, String createdAt, String updatedAt) {
         this.id = id;
         this.email = email;
         this.quota = quota;

--- a/src/main/java/me/shivzee/util/Attachment.java
+++ b/src/main/java/me/shivzee/util/Attachment.java
@@ -19,12 +19,12 @@ public class Attachment {
     private String contentType;
     private String disposition;
     private String transferEncoding;
-    private boolean related;
-    private long size;
+    private Boolean related;
+    private Long size;
     private String downloadUrl;
     private String bearerToken;
 
-    public Attachment(String id, String filename, String contentType, String disposition, String transferEncoding, boolean related, long size, String downloadUrl, String bearerToken) {
+    public Attachment(String id, String filename, String contentType, String disposition, String transferEncoding, Boolean related, long size, String downloadUrl, String bearerToken) {
         this.id = id;
         this.filename = filename;
         this.contentType = contentType;

--- a/src/main/java/me/shivzee/util/Message.java
+++ b/src/main/java/me/shivzee/util/Message.java
@@ -24,15 +24,15 @@ public class Message {
     private List<Receiver> receivers;
     private String subject;
     private String content;
-    private boolean seen;
-    private boolean flagged;
-    private boolean isDeleted;
-    private boolean retention;
+    private Boolean seen;
+    private Boolean flagged;
+    private Boolean isDeleted;
+    private Boolean retention;
     private String retentionDate;
     private String rawHTML;
-    private boolean hasAttachments;
+    private Boolean hasAttachments;
     private List<Attachment> attachments;
-    private long size;
+    private Long size;
     private String downloadUrl;
     private String createdAt;
     private ZonedDateTime createdDateTime;
@@ -41,7 +41,7 @@ public class Message {
     private String bearerToken;
     private String rawJson;
 
-    public Message(String id, String msgid, String senderAddress, String senderName, List<Receiver> receivers, String subject, String content, boolean seen, boolean flagged, boolean isDeleted, boolean retention, String retentionDate, String rawHTML, boolean hasAttachments, List<Attachment> attachments, long size, String downloadUrl, String createdAt,ZonedDateTime createdDateTime, String updatedAt,ZonedDateTime updatedDateTime ,String bearerToken, String rawJson) {
+    public Message(String id, String msgid, String senderAddress, String senderName, List<Receiver> receivers, String subject, String content, Boolean seen, Boolean flagged, Boolean isDeleted, Boolean retention, String retentionDate, String rawHTML, Boolean hasAttachments, List<Attachment> attachments, Long size, String downloadUrl, String createdAt,ZonedDateTime createdDateTime, String updatedAt,ZonedDateTime updatedDateTime ,String bearerToken, String rawJson) {
         this.id = id;
         this.msgid = msgid;
         this.senderAddress = senderAddress;

--- a/src/main/java/me/shivzee/util/Utility.java
+++ b/src/main/java/me/shivzee/util/Utility.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Random;
+import java.util.function.Supplier;
 
 /**
  * The Utility Class for utility ig lmao
@@ -40,6 +41,14 @@ public class Utility {
            throw new DateTimeParserException("Unable to parse Date for :" + dateTime + " With Pattern " + pattern);
         }
         return time;
+    }
+
+    public static <T> T safeEval(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (NullPointerException ex) {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Whenever we retrieve a value from the json field, we use .toString() which could throw NullPointerException. That field may be allowed to have null but since we have .toString() we would end up with NPE. This PR aims at avoiding such NPE. Its a better alternative to null check.
More info on this approach is [here](https://towardsdev.com/stop-checking-for-nulls-in-java-593a1f1a0c2f)

Note : This PR contains the changes made in #6  too.