### PR TITLE
Wrong response code used for Create() function in JMailBuilder

### DIFF
--- a/src/main/java/me/shivzee/util/JMailBuilder.java
+++ b/src/main/java/me/shivzee/util/JMailBuilder.java
@@ -60,7 +60,7 @@ public class JMailBuilder {
             String jsonData = "{\"address\" : \""+email.trim().toLowerCase()+"\",\"password\" : \""+password.trim().toLowerCase()+"\"}";
             Response response = IO.requestPOST(baseUrl+"/accounts" , jsonData);
 
-            return response.getResponseCode() == 200;
+            return response.getResponseCode() == 201;
 
         }catch (Exception e){
             return false;


### PR DESCRIPTION
When trying out the JAVA library in Kotlin, I came across a bug when calling the Create() function in JMailBuilder. At a first instance, I was confused about the fact it returning false. After looking into the decompiled code, I noticed that it was checking for an 200 OK, instead of an 201 Created. 

It is properly done in the CreateAndLogin() function.