### PR TITLE
Treat account creation as successful on response code 200 or 201

### DIFF
--- a/src/main/java/me/shivzee/util/JMailBuilder.java
+++ b/src/main/java/me/shivzee/util/JMailBuilder.java
@@ -58,7 +58,7 @@ public class JMailBuilder {
             String jsonData = "{\"address\" : \""+email.trim().toLowerCase()+"\",\"password\" : \""+password.trim().toLowerCase()+"\"}";
             Response response = IO.requestPOST(baseUrl+"/accounts" , jsonData);
 
-            return response.getResponseCode() == 200;
+            return response.getResponseCode() == 200 || response.getResponseCode() == 201;
 
         }catch (Exception e){
             return false;


### PR DESCRIPTION
The API returns HTTP response status code `201` when account is successfully created, but currently the `create` function will only return `true` if the status equals `200`, so successful account creation is currently treated as failed and resulting in `false` being returned.